### PR TITLE
update package.json typings location to correspond to actual location

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.2",
   "description": "Node.js module for communicating with the Veryfi OCR API",
   "main": "lib/main.js",
-  "typings": "types/main.d.ts",
+  "typings": "lib/types/main.d.ts",
   "scripts": {
     "test": "jest",
     "doc": "jsdoc -d docs --configure jsconf.json main.js",


### PR DESCRIPTION
Based on my quick test, typescript is not able to find the typing with the current path in typings because it doesn't include `lib` in the path.