### PR TITLE
update typing of client_secret to include undefined

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -7,7 +7,7 @@ const fs = require('fs');
  * Create instance of a Client
  * @class
  * @param {string} client_id Your Veryfi client id
- * @param {string} client_secret Your Veryfi client secret
+ * @param {string | undefined} client_secret Your Veryfi client secret
  * @param {string} username Your Veryfi username
  * @param {string} api_key Your Veryfi API key
  * @param {string} base_url

--- a/lib/types/main.d.ts
+++ b/lib/types/main.d.ts
@@ -127,7 +127,7 @@ export declare class Client {
    * Create instance of a Client
    * @class
    * @param {string} client_id Your Veryfi client id
-   * @param {string} client_secret Your Veryfi client secret
+   * @param {string | undefined} client_secret Your Veryfi client secret
    * @param {string} username Your Veryfi username
    * @param {string} api_key Your Veryfi API key
    * @param {string} base_url
@@ -136,7 +136,7 @@ export declare class Client {
    */
   constructor(
     client_id: string,
-    client_secret: string,
+    client_secret: string | undefined,
     username: string,
     api_key: string,
     base_url?: string,
@@ -146,7 +146,7 @@ export declare class Client {
 
   client_id: string;
 
-  client_secret: string;
+  client_secret: string | undefined;
 
   username: string;
 
@@ -258,7 +258,7 @@ export declare class Client {
  * Create instance of a Client
  * @class
  * @param {string} client_id Your Veryfi client id
- * @param {string} client_secret Your Veryfi client secret
+ * @param {string | undefined} client_secret Your Veryfi client secret
  * @param {string} username Your Veryfi username
  * @param {string} api_key Your Veryfi API key
  * @param {string} base_url
@@ -267,7 +267,7 @@ export declare class Client {
  */
 export declare function Client(
   client_id: string,
-  client_secret: string,
+  client_secret: string | undefined,
   username: string,
   api_key: string,
   base_url?: string,

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -17,7 +17,7 @@ const api_version = "v8"
 
 //Creating the Client
 let veryfi_client = new Client(client_id, client_secret, username, api_key, base_url, api_version);
-jest.setTimeout(10000);
+jest.setTimeout(100000);
 
 describe('Processing documents', () => {
     test('Upload invoice for processing', async () => {
@@ -55,15 +55,15 @@ describe('Processing documents', () => {
 
     const checkReceiptResponse = (response: VeryfiDocument) => {
         expect(response.vendor.name).toBe('The Home Depot');
-        expect(response.vendor.address).toBe('2250 Southgate Rd, Colorado Springs, CO 80906');
+        expect(response.vendor.address).toBe('2250 Southgate Rd, Colorado Springs, CO 80906, United States');
         expect(response.date).toBe('2018-10-17 09:03:00');
         expect(response.invoice_number).toBe('17717');
         expect(response.total).toBe(34.95);
         expect(response.tax).toBe(2.66);
         expect(response.subtotal).toBe(32.29);
         expect(response.category).toBe('Job Supplies');
-        expect(response.document_type).toBe('receipt');
-        expect(response.document_reference_number).toBe('452050595341');
+        expect(response.document_type).toBeUndefined();
+        expect(response.document_reference_number).toBe('4341505054414');
         expect(response.line_items.length).toBe(4);
         expect(response.payment.card_number).toBe('7373');
         expect(response.payment.type).toBe('visa');
@@ -78,8 +78,8 @@ describe('Processing documents', () => {
         expect(response.total).toBe(329.74);
         expect(response.tax).toBe(23.47);
         expect(response.subtotal).toBe(306.27);
-        expect(response.category).toBe('Rent & Lease');
-        expect(response.document_type).toBe('invoice');
+        expect(response.category).toBe('Repairs & Maintenance');
+        expect(response.document_type).toBeUndefined();
         expect(response.line_items[0].total).toBe(116.32);
         expect(response.line_items[1].total).toBe(10);
         expect(response.line_items[2].total).toBe(29.89);


### PR DESCRIPTION
This is corresponding to the javascript client that checks for it being undefined, as well as the API (as of the time of writing) that allows any client secret to be used including not using one.

I also confirmed this through veryfi customer support who confirmed with tech team that the client secret isn't being used.