### PR TITLE
Feature/lp 949 update nodejs

### DIFF
--- a/lib/anydocs/processAnyDocumentStream.js
+++ b/lib/anydocs/processAnyDocumentStream.js
@@ -5,7 +5,7 @@ const Client = require('../client/constructor');
  * veryfi_client.process_any_document('file/path','blue_print')
  *
  * @memberof Client
- * @param {ReadStream} file ReadStream of a file to submit for data extraction
+ * @param {stream.Readable} file ReadStream of a file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {String} blueprint_name The name of the extraction blueprints to use.
  * @param {number} max_pages_to_process The number of pages to process for the document. The limit is 50 pages per document.

--- a/lib/bankstatements/processBankStatementStream.js
+++ b/lib/bankstatements/processBankStatementStream.js
@@ -3,7 +3,7 @@ const Client = require('../client/constructor');
  * Process bank statement and extract all the fields from it. https://docs.veryfi.com/api/bank-statements/process-a-bank-statement/
  *
  * @memberof Client
- * @param {fs.ReadStream} file file to submit for data extraction
+ * @param {stream.Readable} file file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
  * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.

--- a/lib/businesscards/processBusinessCardStream.js
+++ b/lib/businesscards/processBusinessCardStream.js
@@ -3,7 +3,7 @@ const Client = require('../client/constructor');
  * Process Business card and extract all the fields from it. https://docs.veryfi.com/api/business-cards/process-a-business-card/
  *
  * @memberof Client
- * @param {fs.ReadStream} file file to submit for data extraction
+ * @param {stream.Readable} file file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {Object} kwargs Additional request parameters
  * @returns {JSON} Data extracted from the document

--- a/lib/checks/processCheckStream.js
+++ b/lib/checks/processCheckStream.js
@@ -3,7 +3,7 @@ const Client = require('../client/constructor');
  * Process Check and extract all the fields from it. https://docs.veryfi.com/api/bank-statements/process-a-bank-statement/
  *
  * @memberof Client
- * @param {fs.ReadStream} file file to submit for data extraction
+ * @param {stream.Readable} file file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
  * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.

--- a/lib/client/getHeaders.js
+++ b/lib/client/getHeaders.js
@@ -8,7 +8,7 @@ const Client = require('../client/constructor');
  */
 Client.prototype._get_headers = function (has_files = false) {
     let final_headers = {
-        "User-Agent": "Node.js Veryfi-Nodejs/1.4.1",
+        "User-Agent": "Node.js Veryfi-Nodejs/1.4.2",
         "Accept": "application/json",
         "Content-Type": "application/json",
         "Client-Id": this.client_id,

--- a/lib/documents/processDocumentStream.js
+++ b/lib/documents/processDocumentStream.js
@@ -9,7 +9,7 @@ const Client = require('../client/constructor');
  *                                {'extra': 'parameters'})
  *
  * @memberof Client
- * @param {ReadStream} file ReadStream of a file to submit for data extraction
+ * @param {stream.Readable} file ReadStream of a file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {Boolean} auto_delete Delete this document from Veryfi after data has been extracted
  * @param {Object} kwargs Additional request parameters

--- a/lib/types/Client.ts
+++ b/lib/types/Client.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import {VeryfiDocument} from "./VeryfiDocument";
 import {JsonObject, VeryfiExtraArgs} from "./VeryfiExtraArgs";
 import {Tag} from "./Tag";
+import * as stream from "node:stream";
 
 export declare class Client {
     /**
@@ -134,7 +135,7 @@ export declare class Client {
      * Process a document and extract all the fields from it. https://docs.veryfi.com/api/receipts-invoices/process-a-document/
      *
      * @memberof Client
-     * @param {fs.ReadStream} file ReadStream of a file to submit for data extraction
+     * @param {stream.Readable} file ReadStream of a file to submit for data extraction
      * @param {String} file_name The file name including the extension
      * @param {Array} categories List of categories Veryfi can use to categorize the document
      * @param {Boolean} auto_delete Delete this document from Veryfi after data has been extracted
@@ -142,7 +143,7 @@ export declare class Client {
      * @returns {JSON} Data extracted from the document
      */
     public process_document_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         categories?: string[],
         auto_delete?: boolean,
@@ -253,7 +254,7 @@ export declare class Client {
      * Process any document and extract all the fields from it. https://docs.veryfi.com/api/anydocs/process-%E2%88%80-doc/
      *
      * @memberof Client
-     * @param {ReadStream} file ReadStream of a file to submit for data extraction
+     * @param {stream.Readable} file ReadStream of a file to submit for data extraction
      * @param {String} file_name The file name including the extension
      * @param {String} blueprint_name The name of the extraction blueprints to use.
      * @param {number} max_pages_to_process The number of pages to process for the document. The limit is 50 pages per document.
@@ -261,7 +262,7 @@ export declare class Client {
      * @returns {JSON} Data extracted from the document
      */
     public process_any_document_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         blueprint_name?: string,
         max_pages_to_process?: number,
@@ -368,7 +369,7 @@ export declare class Client {
      * Process bank statement and extract all the fields from it. https://docs.veryfi.com/api/bank-statements/process-a-bank-statement/
      *
      * @memberof Client
-     * @param {fs.ReadStream} file file to submit for data extraction
+     * @param {stream.Readable} file file to submit for data extraction
      * @param {String} file_name The file name including the extension
      * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
      * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.
@@ -376,7 +377,7 @@ export declare class Client {
      * @returns {JSON} Data extracted from the document
      */
     public process_bank_statement_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         bounding_boxes?: boolean,
         confidence_details?: boolean,
@@ -482,13 +483,13 @@ export declare class Client {
      * Process business card and extract all the fields from it. https://docs.veryfi.com/api/business-cards/process-a-business-card/
      *
      * @memberof Client
-     * @param {fs.ReadStream} file ReadStream of a file to submit for data extraction
+     * @param {stream.Readable} file ReadStream of a file to submit for data extraction
      * @param {String} file_name The file name including the extension
      * @param {Object} kwargs Additional request parameters
      * @returns {JSON} Data extracted from the document
      */
     public process_business_card_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         {...kwargs}?: VeryfiExtraArgs
     ): Promise<JsonObject>;
@@ -606,7 +607,7 @@ export declare class Client {
      * Process check and extract all the fields from it. https://docs.veryfi.com/api/checks/process-a-check/
      *
      * @memberof Client
-     * @param {fs.ReadStream} file file to submit for data extraction
+     * @param {stream.Readable} file file to submit for data extraction
      * @param {String} file_name The file name including the extension
      * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
      * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.
@@ -614,7 +615,7 @@ export declare class Client {
      * @returns {JSON} Data extracted from the document
      */
     public process_check_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         bounding_boxes?: boolean,
         confidence_details?: boolean,
@@ -703,7 +704,7 @@ export declare class Client {
      * Process w2 and extract all the fields from it. https://docs.veryfi.com/api/w2s/process-a-w-2/
      *
      * @memberof Client
-     * @param {fs.ReadStream} file file to submit for data extraction
+     * @param {stream.Readable} file file to submit for data extraction
      * @param {String} file_name The file name including the extension
      * @param {boolean} auto_delete Delete this document from Veryfi after data has been extracted
      * @param {int} max_pages_to_process When sending a long document to Veryfi for processing, this parameter controls how many pages of the document will be read and processed, starting from page 1.
@@ -711,7 +712,7 @@ export declare class Client {
      * @returns {JSON} Data extracted from the document
      */
     public process_w2_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         auto_delete?: boolean,
         max_pages_to_process?: number,
@@ -826,7 +827,7 @@ export declare class Client {
      * Process W-8BEN-E and extract all the fields from it. https://docs.veryfi.com/api/w-8ben-e/process-a-w-8-ben-e/
      *
      * @memberof Client
-     * @param {fs.ReadStream} file file to submit for data extraction
+     * @param {stream.Readable} file file to submit for data extraction
      * @param {String} file_name The file name including the extension.
      * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
      * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.
@@ -834,7 +835,7 @@ export declare class Client {
      * @returns {JSON} Data extracted from the document
      */
     public process_w8bene_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         bounding_boxes?: boolean,
         confidence_details?: boolean,
@@ -943,7 +944,7 @@ export declare class Client {
      * Process w9 and extract all the fields from it. https://docs.veryfi.com/api/w9s/process-a-w-9/
      *
      * @memberof Client
-     * @param {fs.ReadStream} file file to submit for data extraction
+     * @param {stream.Readable} file file to submit for data extraction
      * @param {String} file_name The file name including the extension.
      * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
      * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.
@@ -951,7 +952,7 @@ export declare class Client {
      * @returns {JSON} Data extracted from the document
      */
     public process_w9_from_stream(
-        file: fs.ReadStream,
+        file: stream.Readable,
         file_name: string,
         bounding_boxes?: boolean,
         confidence_details?: boolean,

--- a/lib/w2s/processW2Stream.js
+++ b/lib/w2s/processW2Stream.js
@@ -2,7 +2,7 @@ const Client = require('../client/constructor');
 /**
  * Upload a w2 document from a buffer. https://docs.veryfi.com/api/w2s/process-a-w-2/
  * @memberOf Client
- * @param {fs.ReadStream} file file to submit for data extraction
+ * @param {stream.Readable} file file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {boolean} auto_delete Delete this document from Veryfi after data has been extracted
  * @param {int} max_pages_to_process When sending a long document to Veryfi for processing, this parameter controls how many pages of the document will be read and processed, starting from page 1.

--- a/lib/w8bene/processW8BENEStream.js
+++ b/lib/w8bene/processW8BENEStream.js
@@ -3,7 +3,7 @@ const Client = require('../client/constructor');
  * Upload a W-8BEN-E document from a buffer. https://docs.veryfi.com/api/w-8ben-e/process-a-w-8-ben-e/
  *
  * @memberof Client
- * @param {fs.ReadStream} file file to submit for data extraction
+ * @param {stream.Readable} file file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
  * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.

--- a/lib/w9s/processW9Stream.js
+++ b/lib/w9s/processW9Stream.js
@@ -2,7 +2,7 @@ const Client = require('../client/constructor');
 /**
  * Upload a w9 document from a buffer. https://docs.veryfi.com/api/w9s/process-a-w-9/
  * @memberof Client
- * @param {fs.ReadStream} file file to submit for data extraction
+ * @param {stream.Readable} file file to submit for data extraction
  * @param {String} file_name The file name including the extension
  * @param {boolean} bounding_boxes A field used to determine whether to return bounding_box and bounding_region for extracted fields in the Document response.
  * @param {boolean} confidence_details A field used to determine whether to return the score and ocr_score fields in the Document response.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veryfi/veryfi-sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Node.js module for communicating with the Veryfi OCR API",
   "main": "lib/client/client.js",
   "typings": "lib/types/Client.ts",

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -12,7 +12,7 @@ const username = process.env.VERYFI_USERNAME;
 const api_key = process.env.VERYFI_API_KEY;
 const base_url = process.env.VERYFI_URL;
 const timeout = 240000;
-const mock_responses = false;
+const mock_responses = true;
 
 //Creating the Client
 let veryfi_client = new Client(client_id, client_secret, username, api_key, base_url, 240);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -12,7 +12,7 @@ const username = process.env.VERYFI_USERNAME;
 const api_key = process.env.VERYFI_API_KEY;
 const base_url = process.env.VERYFI_URL;
 const timeout = 240000;
-const mock_responses = true;
+const mock_responses = false;
 
 //Creating the Client
 let veryfi_client = new Client(client_id, client_secret, username, api_key, base_url, 240);


### PR DESCRIPTION
Move from fs.ReadStream to stream.Readable

stream.Readable is a more generic type and can accept data sources beyond just file streams, such as network streams, in-memory buffers, or generated data. This makes the function more versatile, able to work with various data sources.

fs.ReadStream extends from stream.Readable