### PR TITLE
PLAT-6845: Remove categories param from multipart request as it is not supported

### DIFF
--- a/lib/client/getHeaders.js
+++ b/lib/client/getHeaders.js
@@ -8,7 +8,7 @@ const Client = require('../client/constructor');
  */
 Client.prototype._get_headers = function (has_files = false) {
     let final_headers = {
-        "User-Agent": "Node.js Veryfi-Nodejs/1.4.2",
+        "User-Agent": "Node.js Veryfi-Nodejs/1.4.3",
         "Accept": "application/json",
         "Content-Type": "application/json",
         "Client-Id": this.client_id,

--- a/lib/documents/processDocument.js
+++ b/lib/documents/processDocument.js
@@ -29,7 +29,6 @@ Client.prototype.process_document = async function (
     return this.process_document_from_stream(
         file,
         file_name,
-        categories,
         auto_delete,
         kwargs
     );

--- a/lib/types/Client.ts
+++ b/lib/types/Client.ts
@@ -137,7 +137,6 @@ export declare class Client {
      * @memberof Client
      * @param {stream.Readable} file ReadStream of a file to submit for data extraction
      * @param {String} file_name The file name including the extension
-     * @param {Array} categories List of categories Veryfi can use to categorize the document
      * @param {Boolean} auto_delete Delete this document from Veryfi after data has been extracted
      * @param {Object} kwargs Additional request parameters
      * @returns {JSON} Data extracted from the document
@@ -145,7 +144,6 @@ export declare class Client {
     public process_document_from_stream(
         file: stream.Readable,
         file_name: string,
-        categories?: string[],
         auto_delete?: boolean,
         {...kwargs}?: VeryfiExtraArgs
     ): Promise<VeryfiDocument>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@veryfi/veryfi-sdk",
-  "version": "1.4.0",
+  "version": "1.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@veryfi/veryfi-sdk",
-      "version": "1.4.0",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@jest/globals": "^29.0.3",
@@ -1427,10 +1427,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4702,9 +4703,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veryfi/veryfi-sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Node.js module for communicating with the Veryfi OCR API",
   "main": "lib/client/client.js",
   "typings": "lib/types/Client.ts",


### PR DESCRIPTION
Categories param is only supported for process document with base64