### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,11 +1,16 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# This workflow will run tests using node and then publish a package when a release is published.
+# Public npm uses Trusted Publishing (OIDC); no NPM_TOKEN secret is required.
+# For more information see: https://docs.npmjs.com/trusted-publishers
 
 name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   build:
@@ -25,12 +30,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
+          registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  
+
   publish-nexus:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the npm publish workflow to trigger on published releases and use Trusted Publishing via OIDC instead of an `NPM_TOKEN` secret. Also grant the workflow the required `id-token` and `contents` permissions and normalize the npm registry URL.