### PR TITLE
Improve npm publish workflow with OIDC setup

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,11 @@
-# This workflow will run tests using node and then publish a package when a release is published.
+# This workflow will install dependencies and publish when a release is published.
 # Public npm uses Trusted Publishing (OIDC); no NPM_TOKEN secret is required.
 # For more information see: https://docs.npmjs.com/trusted-publishers
+#
+# On npmjs.com → @veryfi/veryfi-sdk → Settings → Trusted Publisher, configure:
+#   Organization or user: veryfi
+#   Repository: veryfi-nodejs
+#   Workflow filename: npm-publish.yml  (filename only, not the full path)
 
 name: Node.js Package
 
@@ -9,7 +14,6 @@ on:
     types: [published]
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -19,20 +23,28 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
 
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC trusted publishing
+      contents: read
     steps:
       - uses: actions/checkout@v4
+      # Do not set registry-url here: setup-node writes an empty
+      # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} line that
+      # prevents npm from using the OIDC trusted-publisher flow.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          node-version: 24
+      # Trusted publishing requires npm >= 11.5.1
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish
+        # Do not set NODE_AUTH_TOKEN — OIDC handles auth
 
   publish-nexus:
     needs: build
@@ -41,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
       - run: npm config set "@veryfi:registry" "https://nexus.veryfi.com/repository/npm/"
       - run: npm config set "//nexus.veryfi.com/repository/npm/:username" "${{ secrets.NEXUS_NPM_USERNAME }}"


### PR DESCRIPTION
Update Node.js to version 24 and refine OIDC trusted publishing configuration:
- Remove registry-url from setup-node to prevent auth token conflicts
- Move id-token permission to publish-npm job level
- Ensure npm >= 11.5.1 with 'npm install -g npm@latest'
- Add detailed comments documenting trusted publishing setup and configuration requirements