### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "veryfi-nodejs",
+  "install": "npm ci"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent environment configuration (`.cursor/environment.json`) so `veryfi-nodejs` is fully usable in Cloud Agents.

The SDK is a Node.js library with no dev server. The complete development experience is: install dependencies with `npm ci`, then run the Jest suite. Tests use mocked API responses (`mock_responses = true` in both `test/main.test.js` and `tests/main.test.ts`), so no Veryfi credentials or network access are required.

```json
{
  "name": "veryfi-nodejs",
  "install": "npm ci"
}
```

- No `start`/`terminals` needed — this is a library, not a service.
- No secrets required for the local development and test flow.

## Validation

| Check | Result |
| --- | --- |
| `npm ci` (install) | Success, 0 vulnerabilities |
| `npm ci` idempotence | Passed twice |
| `npm test -- --coverage` | 87 passed / 87 total, 2 suites |
| Fresh Cloud Agent (booted from tested build) | Node v22.14.0, `node_modules` prepopulated, 87/87 tests pass |

The environment was snapshotted, a draft build (`bld-20260819-90890967-07a3-4f07-b531-695aeb75fdaa`) succeeded, and a fresh Cloud Agent booted from that build confirmed dependencies were prepopulated and the full test suite passes offline.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e171bd5a-6689-468c-a27c-43296117550d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e171bd5a-6689-468c-a27c-43296117550d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

