### PR TITLE
Add get_any_document_tags for AnyDoc tags API

### DIFF
--- a/lib/anydocs/getAnyDocumentTags.js
+++ b/lib/anydocs/getAnyDocumentTags.js
@@ -1,0 +1,15 @@
+const Client = require('../client/constructor');
+/**
+ * Return all tags assigned to a specific any document. https://docs.veryfi.com/api/anydocs/get-A-doc-tags/
+ *
+ * @memberof Client
+ * @param {number} document_id The unique identifier of the document.
+ * @param {Object} kwargs Additional request parameters
+ * @returns {JSON} List of tags assigned to a specific any document.
+ */
+Client.prototype.get_any_document_tags = async function (document_id, {...kwargs} = {}) {
+    let endpoint_name = `/any-documents/${document_id}/tags/`;
+    let request_arguments = {};
+    let response = await this._request("GET", endpoint_name, request_arguments, kwargs, false);
+    return response['data'];
+}

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1,6 +1,7 @@
 const Client = require('../client/function');
 require('../anydocs/deleteAnyDocument');
 require('../anydocs/getAnyDocument');
+require('../anydocs/getAnyDocumentTags');
 require('../anydocs/getAnyDocuments');
 require('../anydocs/processAnyDocument');
 require('../anydocs/processAnyDocumentBase64');

--- a/lib/types/Client.ts
+++ b/lib/types/Client.ts
@@ -318,6 +318,16 @@ export declare class Client {
                              {...kwargs}?: VeryfiExtraArgs): Promise<JsonObject>;
 
     /**
+     * Return all tags assigned to a specific any document. https://docs.veryfi.com/api/anydocs/get-A-doc-tags/
+     * @memberof Client
+     * @param {number} document_id The unique identifier of the document.
+     * @param {Object} kwargs Additional request parameters
+     * @returns {Promise<{tags: Tag[]}>} List of tags assigned to a specific any document.
+     */
+    public get_any_document_tags(document_id: number,
+                                 {...kwargs}?: VeryfiExtraArgs): Promise<{tags: Tag[]}>;
+
+    /**
      * Process any document and extract all the fields from it. https://docs.veryfi.com/api/anydocs/process-%E2%88%80-doc/
      * @example
      * veryfi_client.process_any_document('file/path','template_name')

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -377,6 +377,31 @@ describe('Processing any documents', () => {
         }
     });
 
+    test('Get any document tags', async () => {
+        try {
+            if (mock_responses) {
+                const mockResponse = require('../mocks/getTags.json');
+                veryfi_client._request = jest.fn().mockResolvedValue(mockResponse);
+            }
+            const doc_id = 4559535;
+            let response = await veryfi_client.get_any_document_tags(doc_id);
+            expect(response.tags).toBeDefined();
+            expect(response.tags.length).toBeGreaterThan(0);
+            expect(response.tags[0].name).toBeDefined();
+            if (mock_responses) {
+                expect(veryfi_client._request).toHaveBeenCalledWith(
+                    "GET",
+                    `/any-documents/${doc_id}/tags/`,
+                    {},
+                    {},
+                    false
+                );
+            }
+        } catch (error) {
+            throw new Error(error);
+        }
+    });
+
     test('Process any document from file_path', async () => {
         try {
             if (mock_responses) {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -511,6 +511,20 @@ describe('Processing any documents', () => {
         }
     });
 
+    test('Get any document tags', async () => {
+        try {
+            if (mock_responses) {
+                return assert(true)
+            }
+            let docs = await veryfi_client.get_any_documents();
+            const doc_id = docs.results[0].id;
+            let response = await veryfi_client.get_any_document_tags(doc_id);
+            expect(response.tags).toBeDefined();
+        } catch (error) {
+            throw new Error(error);
+        }
+    });
+
     test(`Get any doc with id `, async () => {
         try {
             if (mock_responses) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the missing [Get ∀Doc tags](https://docs.veryfi.com/api/anydocs/get-A-doc-tags/) endpoint to the Node.js SDK.

- New `Client.get_any_document_tags(document_id)` method calls `GET /api/v8/partner/any-documents/{document_id}/tags/`
- Wires the method into the client module and TypeScript declarations
- Adds unit coverage for the request path and tag list response

Example:

```js
const tags = await veryfi_client.get_any_document_tags(document_id);
// { tags: [{ id: 6673474, name: "tag_123" }] }
```

## Test plan
- [x] `npm test -- --coverage`: 89/89 tests passed; `getAnyDocumentTags.js` at 100% coverage
- [x] Focused test asserts `GET /any-documents/{id}/tags/` and a `{ tags: [...] }` response
- [ ] Reviewer: optionally hit a live AnyDoc ID with credentials to confirm the production endpoint

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://veryfi.slack.com/archives/C0BRGA36DV2/p1787169051070479?thread_ts=1787169051.070479&cid=C0BRGA36DV2)

<div><a href="https://cursor.com/agents/bc-20acd641-82c1-4e9f-aece-7e3d569c2f79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20acd641-82c1-4e9f-aece-7e3d569c2f79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

