### PR TITLE
Add delete_any_document_tag to unlink a tag from an AnyDoc

### DIFF
--- a/lib/anydocs/deleteAnyDocumentTag.js
+++ b/lib/anydocs/deleteAnyDocumentTag.js
@@ -1,0 +1,14 @@
+const Client = require('../client/constructor');
+/**
+ * Unlink a tag from a specific any document. https://docs.veryfi.com/api/anydocs/unlink-a-tag-from-a-A-doc/
+ *
+ * @memberof Client
+ * @param {string} document_id ID of the document you'd like to unlink the tag from
+ * @param {string} tag_id ID of the tag you'd like to unlink
+ * @return {JSON} response about the unlinked tag.
+ */
+Client.prototype.delete_any_document_tag = async function (document_id, tag_id) {
+    let endpoint_name = `/any-documents/${document_id}/tags/${tag_id}/`;
+    let request_arguments = {};
+    return this._request("DELETE", endpoint_name, request_arguments);
+}

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1,5 +1,6 @@
 const Client = require('../client/function');
 require('../anydocs/deleteAnyDocument');
+require('../anydocs/deleteAnyDocumentTag');
 require('../anydocs/getAnyDocument');
 require('../anydocs/getAnyDocumentTags');
 require('../anydocs/getAnyDocuments');

--- a/lib/types/Client.ts
+++ b/lib/types/Client.ts
@@ -328,6 +328,16 @@ export declare class Client {
                                  {...kwargs}?: VeryfiExtraArgs): Promise<{tags: Tag[]}>;
 
     /**
+     * Unlink a tag from a specific any document. https://docs.veryfi.com/api/anydocs/unlink-a-tag-from-a-A-doc/
+     *
+     * @memberof Client
+     * @param {string} document_id ID of the document you'd like to unlink the tag from
+     * @param {string} tag_id ID of the tag you'd like to unlink
+     * @return {Promise<any>} response about the unlinked tag.
+     */
+    public delete_any_document_tag(document_id: string, tag_id: string): Promise<any>;
+
+    /**
      * Process any document and extract all the fields from it. https://docs.veryfi.com/api/anydocs/process-%E2%88%80-doc/
      * @example
      * veryfi_client.process_any_document('file/path','template_name')

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -377,6 +377,28 @@ describe('Processing any documents', () => {
         }
     });
 
+    test('Unlink a tag from an any document', async () => {
+        try {
+            if (mock_responses) {
+                const mockResponse = require('../mocks/deleteTags.json');
+                veryfi_client._request = jest.fn().mockResolvedValue(mockResponse);
+            }
+            const doc_id = 4559535;
+            const tag_id = 12345;
+            let response = await veryfi_client.delete_any_document_tag(doc_id, tag_id);
+            expect(response).toBeDefined();
+            if (mock_responses) {
+                expect(veryfi_client._request).toHaveBeenCalledWith(
+                    "DELETE",
+                    `/any-documents/${doc_id}/tags/${tag_id}/`,
+                    {}
+                );
+            }
+        } catch (error) {
+            throw new Error(error);
+        }
+    });
+
     test('Get any document tags', async () => {
         try {
             if (mock_responses) {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -511,6 +511,22 @@ describe('Processing any documents', () => {
         }
     });
 
+    test('Unlink a tag from an any document', async () => {
+        try {
+            if (mock_responses) {
+                return assert(true)
+            }
+            let docs = await veryfi_client.get_any_documents();
+            const doc_id = docs.results[0].id;
+            const tags = await veryfi_client.get_any_document_tags(doc_id);
+            const tag_id = tags.tags[0].id;
+            let response = await veryfi_client.delete_any_document_tag(doc_id, tag_id);
+            expect(response).toBeDefined();
+        } catch (error) {
+            throw new Error(error);
+        }
+    });
+
     test('Get any document tags', async () => {
         try {
             if (mock_responses) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the missing AnyDocs unlink-tag helper from [Unlink a tag from a ∀Doc](https://docs.veryfi.com/api/anydocs/unlink-a-tag-from-a-A-doc/).

## Changes
- Add `Client.prototype.delete_any_document_tag(document_id, tag_id)` which sends `DELETE /any-documents/{document_id}/tags/{tag_id}/`
- Wire the module into `lib/client/client.js` and add a TypeScript declaration
- Cover the new method with mocked JS tests (including the request path) and a TS test stub that matches existing AnyDoc tests

Usage:

```js
await veryfi_client.delete_any_document_tag(document_id, tag_id);
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://veryfi.slack.com/archives/D0A06BN0ZJS/p1787167426115679?thread_ts=1787167426.115679&cid=D0A06BN0ZJS)

<div><a href="https://cursor.com/agents/bc-f5a8f7b0-a9fc-5439-b7ae-cb5cf07c6d87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5a8f7b0-a9fc-5439-b7ae-cb5cf07c6d87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

