### PR TITLE
Add AGENTS.md SDK agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Veryfi SDK Agent Instructions
+
+These instructions apply to any Veryfi SDK regardless of implementation
+language (Kotlin, Java, PHP, Node.js, Python, C#, etc.). Apply the rules using
+the conventions, tooling, and idioms of the SDK's language.
+
+## Source of truth
+
+The official Veryfi API documentation is:
+
+https://docs.veryfi.com/
+
+When working on API coverage, API methods, parameters, request handling,
+or SDK functionality, the official documentation is the source of truth.
+
+Do not assume the existing SDK represents the complete or current API.
+
+Before implementing or changing an API method:
+
+1. Find the corresponding endpoint in https://docs.veryfi.com/
+2. Read the complete endpoint documentation.
+3. Verify:
+   - HTTP method
+   - API path
+   - path parameters
+   - query parameters
+   - request body parameters
+   - required vs optional parameters
+   - accepted file formats / request encoding
+   - authentication requirements
+   - response structure
+   - async behavior
+   - pagination behavior
+   - examples and documented edge cases
+
+## SDK implementation rules
+
+- Preserve backward compatibility.
+- Do not rename or remove existing public methods unless explicitly requested.
+- Follow the architecture and conventions already used in this repository.
+- Reuse the existing HTTP client and authentication implementation.
+- Do not introduce another HTTP library.
+- Add tests for every new endpoint.
+- Add tests for newly supported parameters.
+- Update the language's inline API documentation and type definitions/signatures
+  where applicable (for example KDoc for Kotlin, Javadoc for Java, PHPDoc for
+  PHP, JSDoc / TypeScript definitions for Node.js, docstrings/type hints for
+  Python).
+- Update README examples for newly exposed functionality.
+
+## API coverage analysis
+
+When asked to analyze API coverage:
+
+Do not immediately implement code.
+
+First compare the complete public Veryfi API documentation against this SDK.
+
+Classify each API operation as:
+
+- IMPLEMENTED
+- PARTIAL
+- MISSING
+- UNCERTAIN
+
+IMPLEMENTED means the SDK exposes the endpoint and supports the currently
+documented parameters.
+
+PARTIAL means the SDK exposes the endpoint but is missing documented
+parameters, options, behavior, or response handling.
+
+MISSING means no public SDK method exposes the operation.
+
+UNCERTAIN means coverage cannot be proven from the repository and documentation.
+
+Always include the documentation URL used to validate each endpoint.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the language-agnostic Veryfi SDK agent instructions from [veryfi-kotlin/AGENTS.md](https://github.com/veryfi/veryfi-kotlin/blob/main/AGENTS.md).

## Changes
- Add `AGENTS.md` so Cloud Agents working on this Node.js SDK treat [docs.veryfi.com](https://docs.veryfi.com/) as the API source of truth
- Keep the same compatibility, testing, docs, and API-coverage analysis rules used by the other Veryfi SDKs

The file is an exact copy of the Kotlin SDK version, which already covers Node.js (JSDoc / TypeScript definitions) among other languages.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://veryfi.slack.com/archives/D0A06BN0ZJS/p1787167426115679?thread_ts=1787167426.115679&cid=D0A06BN0ZJS)

<div><a href="https://cursor.com/agents/bc-a4130e11-e686-5ce3-8b65-ad65cc96aeb0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4130e11-e686-5ce3-8b65-ad65cc96aeb0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

